### PR TITLE
add state: consumed

### DIFF
--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -52,6 +52,7 @@ var ERROR_CODES_BASE = 6777000;
 /*///*/     store.INITIATED  = 'initiated';
 /*///*/     store.APPROVED   = 'approved';
 /*///*/     store.FINISHED   = 'finished';
+/*///*/     store.CONSUMED   = 'consumed';
 /*///*/     store.OWNED      = 'owned';
 /*///*/     store.DOWNLOADING = 'downloading';
 /*///*/     store.DOWNLOADED = 'downloaded';

--- a/src/js/platforms/plugin-adapter.js
+++ b/src/js/platforms/plugin-adapter.js
@@ -206,6 +206,7 @@ store.when("product", "finished", function(product) {
             store.inappbilling.consumePurchase(
                 function() { // success
                     store.log.debug("plugin -> consumable consumed");
+                    product.trigger("consumed");
                     product.set('state', store.VALID);
                 },
                 function(err, code) { // error

--- a/src/js/register.js
+++ b/src/js/register.js
@@ -79,6 +79,7 @@ var keywords = [      ///
     store.APPROVED,   ///  - `approved`
     store.OWNED,      ///  - `owned`
     store.FINISHED,   ///  - `finished`
+    store.CONSUMED,   ///  - `consumed`
     store.DOWNLOADING,///  - `downloading`
     store.DOWNLOADED, ///  - `downloaded`
     'refreshed'       ///  - `refreshed`

--- a/src/js/when.js
+++ b/src/js/when.js
@@ -75,6 +75,7 @@ store.when = function(query, once, callback) {
         addPromise('requested');
         addPromise('initiated');
         addPromise('finished');
+        addPromise('consumed');
 
         ///  - `verified(product)`
         ///    - Called when receipt validation successful

--- a/www/store-android.js
+++ b/www/store-android.js
@@ -36,6 +36,7 @@ store.verbosity = 0;
     store.INITIATED = "initiated";
     store.APPROVED = "approved";
     store.FINISHED = "finished";
+    store.CONSUMED = "consumed";
     store.OWNED = "owned";
     store.DOWNLOADING = "downloading";
     store.DOWNLOADED = "downloaded";
@@ -225,7 +226,7 @@ store.verbosity = 0;
             store.products.push(p);
         }
     }
-    var keywords = [ "product", "order", store.REGISTERED, store.VALID, store.INVALID, store.REQUESTED, store.INITIATED, store.APPROVED, store.OWNED, store.FINISHED, store.DOWNLOADING, store.DOWNLOADED, "refreshed" ];
+    var keywords = [ "product", "order", store.REGISTERED, store.VALID, store.INVALID, store.REQUESTED, store.INITIATED, store.APPROVED, store.OWNED, store.FINISHED, store.CONSUMED, store.DOWNLOADING, store.DOWNLOADED, "refreshed" ];
     function hasKeyword(string) {
         if (!string) return false;
         var tokens = string.split(" ");
@@ -275,6 +276,7 @@ store.verbosity = 0;
             addPromise("requested");
             addPromise("initiated");
             addPromise("finished");
+            addPromise("consumed");
             addPromise("verified");
             addPromise("unverified");
             addPromise("expired");
@@ -990,6 +992,7 @@ store.verbosity = 0;
                 product.transaction = null;
                 store.inappbilling.consumePurchase(function() {
                     store.log.debug("plugin -> consumable consumed");
+                    product.trigger("consumed");
                     product.set("state", store.VALID);
                 }, function(err, code) {
                     store.error({

--- a/www/store-ios.js
+++ b/www/store-ios.js
@@ -36,6 +36,7 @@ store.verbosity = 0;
     store.INITIATED = "initiated";
     store.APPROVED = "approved";
     store.FINISHED = "finished";
+    store.CONSUMED = "consumed";
     store.OWNED = "owned";
     store.DOWNLOADING = "downloading";
     store.DOWNLOADED = "downloaded";
@@ -225,7 +226,7 @@ store.verbosity = 0;
             store.products.push(p);
         }
     }
-    var keywords = [ "product", "order", store.REGISTERED, store.VALID, store.INVALID, store.REQUESTED, store.INITIATED, store.APPROVED, store.OWNED, store.FINISHED, store.DOWNLOADING, store.DOWNLOADED, "refreshed" ];
+    var keywords = [ "product", "order", store.REGISTERED, store.VALID, store.INVALID, store.REQUESTED, store.INITIATED, store.APPROVED, store.OWNED, store.FINISHED, store.CONSUMED, store.DOWNLOADING, store.DOWNLOADED, "refreshed" ];
     function hasKeyword(string) {
         if (!string) return false;
         var tokens = string.split(" ");
@@ -275,6 +276,7 @@ store.verbosity = 0;
             addPromise("requested");
             addPromise("initiated");
             addPromise("finished");
+            addPromise("consumed");
             addPromise("verified");
             addPromise("unverified");
             addPromise("expired");

--- a/www/store-windows.js
+++ b/www/store-windows.js
@@ -36,6 +36,7 @@ store.verbosity = 0;
     store.INITIATED = "initiated";
     store.APPROVED = "approved";
     store.FINISHED = "finished";
+    store.CONSUMED = "consumed";
     store.OWNED = "owned";
     store.DOWNLOADING = "downloading";
     store.DOWNLOADED = "downloaded";
@@ -225,7 +226,7 @@ store.verbosity = 0;
             store.products.push(p);
         }
     }
-    var keywords = [ "product", "order", store.REGISTERED, store.VALID, store.INVALID, store.REQUESTED, store.INITIATED, store.APPROVED, store.OWNED, store.FINISHED, store.DOWNLOADING, store.DOWNLOADED, "refreshed" ];
+    var keywords = [ "product", "order", store.REGISTERED, store.VALID, store.INVALID, store.REQUESTED, store.INITIATED, store.APPROVED, store.OWNED, store.FINISHED, store.CONSUMED, store.DOWNLOADING, store.DOWNLOADED, "refreshed" ];
     function hasKeyword(string) {
         if (!string) return false;
         var tokens = string.split(" ");
@@ -275,6 +276,7 @@ store.verbosity = 0;
             addPromise("requested");
             addPromise("initiated");
             addPromise("finished");
+            addPromise("consumed");
             addPromise("verified");
             addPromise("unverified");
             addPromise("expired");
@@ -990,6 +992,7 @@ store.verbosity = 0;
                 product.transaction = null;
                 store.inappbilling.consumePurchase(function() {
                     store.log.debug("plugin -> consumable consumed");
+                    product.trigger("consumed");
                     product.set("state", store.VALID);
                 }, function(err, code) {
                     store.error({


### PR DESCRIPTION
問題：
finishedの直前にconsumePurchaseが走ると、finishedになったとにitemをprovisioningする必要がある。
itemをprovisioningされる前後でアプリをkillされると、起動時にstate = validになっているため、課金が正常終了しているかどうか（itemのprovisioningが正常にリクエストされているか）が判断できない。

解決策：
finishedの前に新たな状態consumedを挟み、finishied -> consumed -> validのstate flowにすることで、validになっているならば、itemをprovisioningされていることが保証されれるようにした。
